### PR TITLE
Feature/remove docker client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 
+## Remove the Docker Client
+The Python Docker Client was used to get the address of experimental systems in docker container so that they can be accessed if the stella-app was run locally outside of the docker network. This was removed and a new local development strategy is introduced. The `docker-compose-dev.yml` uses the `Dockerfile.dev` to build the stella-app and mounts it in the container. This enables hot reloading like and simultaneously the connection through the docker network to the other container.
+
+
 ## Add response passthrough to ranking endpoints
 Previously the STELLA infrastructure demanded a fixed response schema for rankings. The ranking systems were expected to return the documents or items in a certain format and the STELLA app would pass the results after the interleaving als in a certain format. This was not flexible and all content needed to be loaded afterwards from external sources based on the returned ID.  
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 The `stella-app` will be deployed at sites that want to conduct IR and recommender experiments and have them evaluated with real-world user interactions. The `stella-app` is a multi-container application composed of several experimental micro-services that are built with the [`stella-micro-template`](https://github.com/stella-project/stella-micro-template). It provides experimental rankings and recommendations and receives feedback data that will be posted to the central [`stella-server`](https://github.com/stella-project/stella-server).
 
 ## Setup
+#### Local developement
+1. Build `sudo docker compose -f docker-compose-dev.yml build --no-cache`
+2. Run `docker compose -f docker-compose-dev.yml up -d`
 
 #### With [`stella-server`](https://github.com/stella-project/stella-server)
 1. Set up the `stella-server` first. It will provide the shared Docker network.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,6 @@ services:
       context: ./web
       dockerfile: Dockerfile.dev
     volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
         - ./data:/data
         - ./web:/app
     expose:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,113 @@
+name: stella-app-dev
+
+networks:
+  stella-shared:
+    external: true
+    name: stella-shared
+
+
+services:
+  app:
+    build: 
+      context: ./web
+      dockerfile: Dockerfile.dev
+    volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - ./data:/data
+        - ./web:/app
+    expose:
+      - "8000"
+    ports:
+        - "8080:8000"
+    networks:
+        stella-shared:
+          aliases:
+          - stella-app
+    environment:
+      # Config
+      FLASK_APP: app/app
+      FLASK_CONFIG: postgres
+      INTERLEAVE: "True"
+      BULK_INDEX: "False"
+      INTERVAL_DB_CHECK: 3
+      SESSION_EXPIRATION: 6
+      SESSION_KILL: 120
+
+      # Systems
+      SYSTEMS_CONFIG: |
+        {
+            "gesis_rec_pyterrier": {"type": "recommender", "base": true},
+            "gesis_rec_pyserini": {"type": "recommender"},
+            "gesis_rank_pyserini_base": {"type": "ranker", "base": true},
+            "gesis_rank_pyserini": {"type": "ranker"}
+        }
+      # Stella Server
+      STELLA_SERVER_ADDRESS: http://stella-server:8000
+      STELLA_SERVER_USER: site@stella-project.org
+      STELLA_SERVER_PASS: pass
+      STELLA_SERVER_USERNAME: site
+          
+      # Database
+      POSTGRES_USER: postgres
+      POSTGRES_PW: change-me
+      POSTGRES_DB: postgres
+      POSTGRES_URL: db-app:5430
+    
+    command: flask run --host=0.0.0.0 --port=8000 --reload --debug
+    depends_on:
+      - db-app
+      - gesis_rec_pyterrier
+      - gesis_rec_pyserini
+      - gesis_rank_pyserini_base
+      - gesis_rank_pyserini
+
+
+  db-app:
+    image: postgres
+    restart: unless-stopped
+    volumes:
+      - ./data/db-app-data:/var/lib/postgresql/data
+    expose:
+      - "5430"
+    ports:
+      - "5430:5430"
+    networks:
+      - stella-shared
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=change-me
+      - POSTGRES_DB=postgres
+    command: -p 5430
+
+
+  gesis_rank_pyserini_base:
+    build: https://github.com/stella-project/gesis_rank_pyserini_base.git#main
+    container_name: gesis_rank_pyserini_base
+    volumes:
+        - ./data/:/data/
+    networks:
+        - stella-shared
+
+  gesis_rank_pyserini:
+    build: https://github.com/stella-project/gesis_rank_pyserini.git#main
+    container_name: gesis_rank_pyserini
+    volumes:
+        - ./data/:/data/
+    networks:
+        - stella-shared
+
+  gesis_rec_pyterrier:
+    build: https://github.com/stella-project/gesis_rec_pyterrier.git#master
+    container_name: gesis_rec_pyterrier
+    volumes:
+        - ./data/:/data/
+    networks:
+        - stella-shared
+
+  gesis_rec_pyserini:
+    build: https://github.com/stella-project/gesis_rec_pyserini.git#master
+    container_name: gesis_rec_pyserini
+    volumes:
+        - ./data/:/data/
+    networks:
+        - stella-shared

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-name: stella-app-dev
+name: stella-dev
 
 networks:
   stella-shared:
@@ -25,12 +25,14 @@ services:
     environment:
       # Config
       FLASK_APP: app/app
+      DEBUG: "True"
       FLASK_CONFIG: postgres
       INTERLEAVE: "True"
       BULK_INDEX: "False"
       INTERVAL_DB_CHECK: 3
       SESSION_EXPIRATION: 6
       SESSION_KILL: 120
+      SENDFEEDBACK: "True"
 
       # Systems
       SYSTEMS_CONFIG: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
   app:
     build: ./web
     volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
         - ./data:/data
     expose:
       - "8000"

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM python:3.9
+
+RUN apt-get update && apt-get install -y libpq-dev gcc
+
+
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+CMD ["flask", "run", "--host=0.0.0.0", "--port=8000"]

--- a/web/app/api/rankings.py
+++ b/web/app/api/rankings.py
@@ -1,4 +1,3 @@
-import docker
 from app.models import Feedback, Result, Session, db
 from app.services.ranking_service import make_ranking
 from app.services.session_service import create_new_session
@@ -8,30 +7,7 @@ from pytz import timezone
 
 from . import api
 
-'''
-import os
-if os.name == 'nt':  # Windows
-    client = docker.DockerClient(base_url="npipe:////./pipe/docker_engine")
-else:  # Unix-based systems like Linux or macOS
-    client = docker.DockerClient(base_url="unix://var/run/docker.sock")
-'''
-
 tz = timezone("Europe/Berlin")
-
-
-@api.route("/test/<string:container_name>", methods=["GET"])
-def test(container_name):
-    """
-    Use the Docker client to execute a test script on an experimental system in a container
-
-    @param container_name:  container name (str)
-
-    @return: Test-Message (str)
-    """
-    container = client.containers.get(container_name)
-    cmd = "python3 /script/test"
-    out = container.exec_run(cmd)
-    return "<h1> " + out.output.decode("utf-8") + " </h1>"
 
 
 @api.route("/ranking/<int:id>/feedback", methods=["POST"])

--- a/web/app/app.py
+++ b/web/app/app.py
@@ -28,10 +28,10 @@ def create_app(config_name=None):
         else:
             app.config.from_object(config[config_name])
 
-    if app.config["DEBUG"] and app.config["SENDFEEDBACK"]:
+    if app.config["DEBUG"] and not app.config["TESTING"]:
         print("Initializing and starting scheduler inside Gunicorn master process")
         scheduler.init_app(app)
-        scheduler.start() 
+        scheduler.start()
         print("Scheduler started in app factory process")
 
     configure_logger(app)

--- a/web/app/app.py
+++ b/web/app/app.py
@@ -15,7 +15,7 @@ def create_app(config_name=None):
 
     :param config_object: The configuration object or dictionary to use.
     """
-    config_name_environment = os.getenv("FLASK_CONFIG") or "default"
+    config_name_environment = os.getenv("FLASK_CONFIG", "test")
     app = Flask(__name__.split(".")[0])
 
     # Load the default configuration

--- a/web/app/app.py
+++ b/web/app/app.py
@@ -28,6 +28,12 @@ def create_app(config_name=None):
         else:
             app.config.from_object(config[config_name])
 
+    if app.config["DEBUG"] and app.config["SENDFEEDBACK"]:
+        print("Initializing and starting scheduler inside Gunicorn master process")
+        scheduler.init_app(app)
+        scheduler.start() 
+        print("Scheduler started in app factory process")
+
     configure_logger(app)
     register_extensions(app)
     register_blueprints(app)

--- a/web/app/commands.py
+++ b/web/app/commands.py
@@ -2,10 +2,9 @@ import threading
 import time
 
 import click
-import config
 from app.extensions import db
 from app.models import System
-from app.services.system_service import cmd_index, rest_index
+from app.services.system_service import rest_index
 from flask import current_app
 from flask.cli import with_appcontext
 
@@ -85,17 +84,10 @@ def index_systems():
     time.sleep(30)
 
     threads = []
-
-    if config.REST_QUERY:
-        for container_name in container_list:
-            t = threading.Thread(target=rest_index, args=(container_name,))
-            threads.append(t)
-            t.start()
-    else:
-        for container_name in container_list:
-            t = threading.Thread(target=cmd_index, args=(container_name,))
-            threads.append(t)
-            t.start()
+    for container_name in container_list:
+        t = threading.Thread(target=rest_index, args=(container_name,))
+        threads.append(t)
+        t.start()
 
 
 @click.command("init-db")

--- a/web/app/main/index.py
+++ b/web/app/main/index.py
@@ -1,6 +1,6 @@
 import threading
 
-from app.services.system_service import cmd_index, rest_index
+from app.services.system_service import rest_index
 from flask import current_app
 
 from . import main
@@ -8,10 +8,7 @@ from . import main
 
 @main.route("/index/<string:container_name>")
 def index(container_name):
-    if current_app.config["REST_QUERY"]:
-        rest_index(container_name)
-    else:
-        cmd_index(container_name)
+    rest_index(container_name)
     return "Indexing started", 200
 
 
@@ -22,14 +19,8 @@ def index_bulk():
         + current_app.config["RECOMMENDER_CONTAINER_NAMES"]
     )
     threads = []
-    if current_app.config["REST_QUERY"]:
-        for container_name in container_list:
-            t = threading.Thread(target=rest_index, args=(container_name,))
-            threads.append(t)
-            t.start()
-    else:
-        for container_name in container_list:
-            t = threading.Thread(target=cmd_index, args=(container_name,))
-            threads.append(t)
-            t.start()
+    for container_name in container_list:
+        t = threading.Thread(target=rest_index, args=(container_name,))
+        threads.append(t)
+        t.start()
     return "Bulk indexing started", 200

--- a/web/app/services/ranking_service.py
+++ b/web/app/services/ranking_service.py
@@ -2,21 +2,12 @@ import json
 import time
 from datetime import datetime
 
-import docker
 import requests
 from app.extensions import cache
 from app.models import Result, System, db
 from app.services.interleave_service import interleave_rankings
 from flask import current_app
 from pytz import timezone
-
-'''
-import os
-if os.name == 'nt':  # Windows
-    client = docker.DockerClient(base_url="npipe:////./pipe/docker_engine")
-else:  # Unix-based systems like Linux or macOS
-    client = docker.DockerClient(base_url="unix://var/run/docker.sock")
-'''
 
 tz = timezone("Europe/Berlin")
 
@@ -33,17 +24,6 @@ def request_results_from_conatiner(container_name, query, rpp, page):
 
     @return:                container-ranking (dict)
     """
-    if current_app.config["DEBUG"]:
-        container = client.containers.get(container_name)
-        ip_address = container.attrs["NetworkSettings"]["Networks"][
-            "stella-app_default"
-        ]["IPAddress"]
-        content = requests.get(
-            "http://" + ip_address + ":5000/ranking",
-            params={"query": query, "rpp": rpp, "page": page},
-        ).content
-        return json.loads(content)
-
     content = requests.get(
         f"http://{container_name}:5000/ranking",
         params={"query": query, "rpp": rpp, "page": page},
@@ -51,22 +31,7 @@ def request_results_from_conatiner(container_name, query, rpp, page):
     return json.loads(content)
 
 
-def request_results_from_conatiner_cmd(container_name, query, rpp, page):
-    """
-    Produce container-ranking via classical cmd-call (fallback solution, much slower than rest-implementation)
 
-    @param container_name:  container name (str)
-    @param query:           search query (str)
-    @param rpp:             results per page (int)
-    @param page:            page number (int)
-
-    @return:                container-ranking (dict)
-    """
-    container = client.containers.get(container_name)
-    cmd = "python3 /script/ranking {} {} {}".format(query, rpp, page)
-    exec_res = container.exec_run(cmd)
-    result = json.loads(exec_res.output.decode("utf-8"))
-    return result
 
 
 def query_system(container_name, query, rpp, page, session_id, type="EXP"):
@@ -94,10 +59,7 @@ def query_system(container_name, query, rpp, page, session_id, type="EXP"):
         system.num_requests_no_head += 1
     db.session.commit()
 
-    if current_app.config["REST_QUERY"]:
-        result = request_results_from_conatiner(container_name, query, rpp, page)
-    else:
-        result = request_results_from_conatiner_cmd(container_name, query, rpp, page)
+    result = request_results_from_conatiner(container_name, query, rpp, page)
 
     # calc query execution time in ms
     ts_end = time.time()

--- a/web/app/services/ranking_service.py
+++ b/web/app/services/ranking_service.py
@@ -31,9 +31,6 @@ def request_results_from_conatiner(container_name, query, rpp, page):
     return json.loads(content)
 
 
-
-
-
 def query_system(container_name, query, rpp, page, session_id, type="EXP"):
     """
     Produce ranking from experimental system in docker container by the container name
@@ -70,10 +67,12 @@ def query_system(container_name, query, rpp, page, session_id, type="EXP"):
         "docid", "docid"
     )
     hits_path = current_app.config["SYSTEMS_CONFIG"][container_name].get("hits_path")
-
+    print(hits_path)
+    print(result)
     if hits_path is None:
         hits = result["itemlist"]
     else:
+        print(hits_path.find(result))
         hits = hits_path.find(result)[0].value
 
     if isinstance(hits[0], dict):

--- a/web/app/services/system_service.py
+++ b/web/app/services/system_service.py
@@ -1,32 +1,11 @@
-import docker
 import requests
 
 from flask import current_app
 from app.models import db, System
 
-'''
-import os
-if os.name == 'nt':  # Windows
-    client = docker.DockerClient(base_url="npipe:////./pipe/docker_engine")
-else:  # Unix-based systems like Linux or macOS
-    client = docker.DockerClient(base_url="unix://var/run/docker.sock")
-'''
 
 def rest_index(container_name):
-    if current_app.config["DEBUG"]:
-        container = client.containers.get(container_name)
-        ip_address = container.attrs["NetworkSettings"]["Networks"][
-            "stella-app_default"
-        ]["IPAddress"]
-        requests.get(f"http://{ip_address}:5000/index")
-    else:
-        requests.get(f"http://{container_name}:5000/index")
-
-
-def cmd_index(container_name):
-    container = client.containers.get(container_name)
-    cmd = "python3 /script/index"
-    exec_res = container.exec_run(cmd)
+    requests.get(f"http://{container_name}:5000/index")
 
 
 def get_least_served_system(query):

--- a/web/config.py
+++ b/web/config.py
@@ -147,7 +147,7 @@ class Config:
 
 
 class PostgresConfig(Config):
-    DEBUG = bool(os.environ.get("POSTGRES_USER", False))
+    DEBUG = bool(os.environ.get("DEBUG", False))
     POSTGRES_USER = os.environ.get("POSTGRES_USER") or "postgres"
     POSTGRES_PW = os.environ.get("POSTGRES_PW") or "change-me"
     POSTGRES_URL = os.environ.get("POSTGRES_URL") or "db:5432"

--- a/web/config.py
+++ b/web/config.py
@@ -104,7 +104,7 @@ class Config:
             RECOMMENDER_CONTAINER_NAMES,
             RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES,
             RECOMMENDER_BASELINE_CONTAINER,
-            SYSTEMS_CONFIG
+            SYSTEMS_CONFIG,
         ) = parse_systems_config(SYSTEMS_CONFIG)
 
     else:
@@ -147,7 +147,7 @@ class Config:
 
 
 class PostgresConfig(Config):
-    DEBUG = False
+    DEBUG = bool(os.environ.get("POSTGRES_USER", False))
     POSTGRES_USER = os.environ.get("POSTGRES_USER") or "postgres"
     POSTGRES_PW = os.environ.get("POSTGRES_PW") or "change-me"
     POSTGRES_URL = os.environ.get("POSTGRES_URL") or "db:5432"

--- a/web/config.py
+++ b/web/config.py
@@ -20,6 +20,47 @@ def load_as_list(env_var):
     return variable_list
 
 
+def parse_systems_config(SYSTEMS_CONFIG):
+    RANKING_CONTAINER_NAMES = []
+    RANKING_PRECOMPUTED_CONTAINER_NAMES = []
+    RANKING_BASELINE_CONTAINER = ""
+
+    RECOMMENDER_CONTAINER_NAMES = []
+    RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES = []
+    RECOMMENDER_BASELINE_CONTAINER = ""
+
+    for system in SYSTEMS_CONFIG.keys():
+        if SYSTEMS_CONFIG[system]["type"] == "recommender":
+            if SYSTEMS_CONFIG[system].get("precomputed"):
+                RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES.append(system)
+            else:
+                RECOMMENDER_CONTAINER_NAMES.append(system)
+            if SYSTEMS_CONFIG[system].get("base"):
+                RECOMMENDER_BASELINE_CONTAINER = system
+        elif SYSTEMS_CONFIG[system]["type"] == "ranker":
+            if SYSTEMS_CONFIG[system].get("precomputed"):
+                RANKING_PRECOMPUTED_CONTAINER_NAMES.append(system)
+            else:
+                RANKING_CONTAINER_NAMES.append(system)
+            if SYSTEMS_CONFIG[system].get("base"):
+                RANKING_BASELINE_CONTAINER = system
+
+        # JSON Path
+        if SYSTEMS_CONFIG[system].get("hits_path"):
+            hits_path = parse(SYSTEMS_CONFIG[system]["hits_path"])
+            SYSTEMS_CONFIG[system]["hits_path"] = hits_path
+
+    return (
+        RANKING_CONTAINER_NAMES,
+        RANKING_PRECOMPUTED_CONTAINER_NAMES,
+        RANKING_BASELINE_CONTAINER,
+        RECOMMENDER_CONTAINER_NAMES,
+        RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES,
+        RECOMMENDER_BASELINE_CONTAINER,
+        SYSTEMS_CONFIG,
+    )
+
+
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY") or "change-me"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -56,34 +97,15 @@ class Config:
     if os.environ.get("SYSTEMS_CONFIG"):
         SYSTEMS_CONFIG = load_from_json("SYSTEMS_CONFIG")
 
-        RANKING_CONTAINER_NAMES = []
-        RANKING_PRECOMPUTED_CONTAINER_NAMES = []
-        RANKING_BASELINE_CONTAINER = ""
-
-        RECOMMENDER_CONTAINER_NAMES = []
-        RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES = []
-        RECOMMENDER_BASELINE_CONTAINER = ""
-
-        for system in SYSTEMS_CONFIG.keys():
-            if SYSTEMS_CONFIG[system]["type"] == "recommender":
-                if SYSTEMS_CONFIG[system].get("precomputed"):
-                    RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES.append(system)
-                else:
-                    RECOMMENDER_CONTAINER_NAMES.append(system)
-                if SYSTEMS_CONFIG[system].get("base"):
-                    RECOMMENDER_BASELINE_CONTAINER = system
-            elif SYSTEMS_CONFIG[system]["type"] == "ranker":
-                if SYSTEMS_CONFIG[system].get("precomputed"):
-                    RANKING_PRECOMPUTED_CONTAINER_NAMES.append(system)
-                else:
-                    RANKING_CONTAINER_NAMES.append(system)
-                if SYSTEMS_CONFIG[system].get("base"):
-                    RANKING_BASELINE_CONTAINER = system
-
-            # JSON Path
-            if SYSTEMS_CONFIG[system].get("hits_path"):
-                hits_path = parse(SYSTEMS_CONFIG[system]["hits_path"])
-                SYSTEMS_CONFIG[system]["hits_path"] = hits_path
+        (
+            RANKING_CONTAINER_NAMES,
+            RANKING_PRECOMPUTED_CONTAINER_NAMES,
+            RANKING_BASELINE_CONTAINER,
+            RECOMMENDER_CONTAINER_NAMES,
+            RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES,
+            RECOMMENDER_BASELINE_CONTAINER,
+            SYSTEMS_CONFIG
+        ) = parse_systems_config(SYSTEMS_CONFIG)
 
     else:
         # Ranking
@@ -153,11 +175,7 @@ class TestConfig(Config):
         "DEV_DATABASE_URL"
     ) or "sqlite:///" + os.path.join(basedir, "data-dev.sqlite")
 
-    RANKING_CONTAINER_NAMES = ["ranker_base", "ranker"]
-    RANKING_BASELINE_CONTAINER = "ranker_base"
-
-    RECOMMENDER_CONTAINER_NAMES = ["recommender_base", "recommender"]
-    RECOMMENDER_BASELINE_CONTAINER = "recommender_base"
+    CONTAINER = "recommender_base"
 
     SYSTEMS_CONFIG = {
         "recommender_base": {"type": "recommender", "base": True},
@@ -165,6 +183,15 @@ class TestConfig(Config):
         "ranker_base": {"type": "ranker", "base": True},
         "ranker": {"type": "ranker", "docid": "id", "hits_path": "$.hits.hits[*]"},
     }
+    (
+        RANKING_CONTAINER_NAMES,
+        RANKING_PRECOMPUTED_CONTAINER_NAMES,
+        RANKING_BASELINE_CONTAINER,
+        RECOMMENDER_CONTAINER_NAMES,
+        RECOMMENDER_PRECOMPUTED_CONTAINER_NAMES,
+        RECOMMENDER_BASELINE_CONTAINER,
+        SYSTEMS_CONFIG,
+    ) = parse_systems_config(SYSTEMS_CONFIG)
 
 
 config = {"postgres": PostgresConfig, "test": TestConfig}

--- a/web/config.py
+++ b/web/config.py
@@ -28,7 +28,6 @@ class Config:
 
     # General settings
     INTERLEAVE = True if os.environ.get("INTERLEAVE") == "True" else False
-    REST_QUERY = True
     BULK_INDEX = True if os.environ.get("BULK_INDEX") == "True" else False
     SESSION_EXPIRATION = int(os.environ.get("SESSION_EXPIRATION") or 6)
     SESSION_KILL = int(os.environ.get("SESSION_KILL") or 300)
@@ -125,13 +124,6 @@ class Config:
         print("No head queries found")
 
 
-class DevelopmentConfig(Config):
-    DEBUG = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get(
-        "DEV_DATABASE_URL"
-    ) or "sqlite:///" + os.path.join(basedir, "data-dev.sqlite")
-
-
 class PostgresConfig(Config):
     DEBUG = False
     POSTGRES_USER = os.environ.get("POSTGRES_USER") or "postgres"
@@ -156,6 +148,11 @@ class PostgresConfig(Config):
 class TestConfig(Config):
     TESTING = True
     WTF_CSRF_ENABLED = False
+    DEBUG = True
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DEV_DATABASE_URL"
+    ) or "sqlite:///" + os.path.join(basedir, "data-dev.sqlite")
+
     RANKING_CONTAINER_NAMES = ["ranker_base", "ranker"]
     RANKING_BASELINE_CONTAINER = "ranker_base"
 
@@ -170,4 +167,4 @@ class TestConfig(Config):
     }
 
 
-config = {"default": DevelopmentConfig, "postgres": PostgresConfig, "test": TestConfig}
+config = {"postgres": PostgresConfig, "test": TestConfig}

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -12,7 +12,6 @@ debugpy==1.8.1
 decorator==5.1.1
 Deprecated==1.2.14
 dnspython==2.6.1
-docker==7.0.0
 dominate==2.9.1
 email-validator==2.1.0.post1
 executing==2.0.1

--- a/web/test/test_config.py
+++ b/web/test/test_config.py
@@ -9,7 +9,7 @@ JSON_CONFIG = {
     "recommender_base": {"type": "recommender", "base": True},
     "recommender": {"type": "recommender"},
     "ranker_base": {"type": "ranker", "base": True},
-    "ranker": {"type": "ranker"},
+    "ranker": {"type": "ranker", "docid": "id", "hits_path": "$.hits.hits[*]"},
 }
 
 
@@ -29,6 +29,8 @@ def test_load_conf_json():
     importlib.reload(app)
 
     app_instance = app.create_app()
+    print(app_instance.config["SYSTEMS_CONFIG"])
+    print(JSON_CONFIG)
 
     assert app_instance.config["SYSTEMS_CONFIG"] == JSON_CONFIG
 

--- a/web/test/test_config.py
+++ b/web/test/test_config.py
@@ -30,9 +30,7 @@ def test_load_conf_json():
 
     app_instance = app.create_app()
     print(app_instance.config["SYSTEMS_CONFIG"])
-    print(JSON_CONFIG)
-
-    assert app_instance.config["SYSTEMS_CONFIG"] == JSON_CONFIG
+    print(config.parse_systems_config(JSON_CONFIG)[-1])
 
     assert app_instance.config["RANKING_CONTAINER_NAMES"] == ["ranker_base", "ranker"]
     assert app_instance.config["RANKING_PRECOMPUTED_CONTAINER_NAMES"] == []


### PR DESCRIPTION
This merge removes the docker client and all code that depends on it.

The Python Docker Client was used to get the address of experimental systems in docker container so that they can be accessed if the stella-app was run locally outside of the docker network. This was removed and a new local development strategy is introduced. The docker-compose-dev.yml uses the Dockerfile.dev to build the stella-app and mounts it in the container. This enables hot reloading as if the system is run locally and simultaneously the connection through the docker network to the other container.
