### PR TITLE
fix: interleaving related resilience issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Release notes
 All notable changes to this project will be documented in this file. 
 
+## Interleaving made resilient
+Team draft interlaving has been updated so the Stella-App returns a result list even when a system:
+- is down or return an empty list
+- returns fewer results than expected
+- responds late 
+
 ## Generalize Recommender Endpoints
 The stella app differentiates between dataset and publication recommendations. While this was catered to the initial use in the Lilas lab, the goal is to support any type of recommendations. Therefore, the recommender endpoint was simplified so that no specific types are supported. Instead of `recommendations/datasets` and `recommendations/publications` simply the `recommendations` endpoint can now be used. 
 

--- a/web/app/services/interleave_service.py
+++ b/web/app/services/interleave_service.py
@@ -5,6 +5,7 @@ from flask import current_app
 
 
 def team_draft_interleave(result_list_base, result_list_exp, rpp):
+    # implementation based on https://bitbucket.org/living-labs/ll-api/src/master/ll/core/interleave.py
     """
     Perform Team Draft Interleaving between two ranked lists.
     

--- a/web/test/services/test_interleave_service.py
+++ b/web/test/services/test_interleave_service.py
@@ -24,6 +24,34 @@ possible_results = [
         2: {"docid": "doc11", "type": "EXP"},
         3: {"docid": "doc2", "type": "BASE"},
     },
+    {
+        1: {"docid": "doc1", "type": "BASE"},
+        2: {"docid": "doc11", "type": "EXP"},
+        3: {"docid": "doc2", "type": "BASE"},
+        4: {"docid": "doc12", "type": "EXP"},
+        5: {"docid": "doc3", "type": "BASE"},
+        6: {"docid": "doc4", "type": "BASE"},
+    },
+    {
+        1: {"docid": "doc11", "type": "EXP"},
+        2: {"docid": "doc1", "type": "BASE"},
+        3: {"docid": "doc12", "type": "EXP"},
+        4: {"docid": "doc2", "type": "BASE"},
+        5: {"docid": "doc3", "type": "BASE"},
+        6: {"docid": "doc4", "type": "BASE"},
+    },
+    {
+        1: {"docid": "doc1", "type": "BASE"},
+        2: {"docid": "doc11", "type": "EXP"},
+        3: {"docid": "doc2", "type": "BASE"},
+        4: {"docid": "doc3", "type": "BASE"},
+    },
+    {
+        1: {"docid": "doc11", "type": "EXP"},
+        2: {"docid": "doc1", "type": "BASE"},
+        3: {"docid": "doc2", "type": "BASE"},
+        4: {"docid": "doc3", "type": "BASE"},
+    },
 ]
 
 
@@ -64,4 +92,69 @@ def test_interleave_rankings(sessions):
     interleaved_results = interleave_rankings(results_exp, results_base, 'ranking', rpp=len(results_base.items))
     # The interleaved dict is added to the Result object which is a JSON type. Therefore the keys are konverted from int to str. Here we revert this conversion.
     interleaved_results = {int(k): v for k, v in interleaved_results.items.items()}
+    assert interleaved_results in possible_results
+
+
+def test_interleave_rankings_exp_fail(sessions):
+    result = create_results(sessions)
+
+    results_base = result["ranker_base"]
+    results_base.items = {
+        1: {"docid": "doc1", "type": "BASE"},
+        2: {"docid": "doc2", "type": "BASE"},
+        3: {"docid": "doc3", "type": "BASE"},
+    }
+
+    results_exp = result["ranker"]
+    results_exp.items = {}
+
+    interleaved_results = interleave_rankings(results_exp, results_base, 'ranking', rpp=len(results_base.items))
+
+    assert interleaved_results.items == results_base.items
+
+
+
+def test_interleave_rankings_less_results_than_expected(sessions):
+    result = create_results(sessions)
+
+    results_base = result["ranker_base"]
+    results_base.items = {
+        1: {"docid": "doc1", "type": "BASE"},
+        2: {"docid": "doc2", "type": "BASE"},
+        3: {"docid": "doc3", "type": "BASE"},
+        4: {"docid": "doc4", "type": "BASE"},
+    }
+
+    results_exp = result["ranker"]
+    results_exp.items = {
+        1: {"docid": "doc11", "type": "EXP"},
+        2: {"docid": "doc12", "type": "EXP"},
+    }
+
+    interleaved_results = interleave_rankings(results_exp, results_base, 'ranking', rpp=6)
+    interleaved_results = {int(k): v for k, v in interleaved_results.items.items()}
+
+    assert interleaved_results in possible_results
+
+
+
+def test_interleave_rankings_unbalanced(sessions):
+    result = create_results(sessions)
+
+    results_base = result["ranker_base"]
+    results_base.items = {
+        1: {"docid": "doc1", "type": "BASE"},
+        2: {"docid": "doc2", "type": "BASE"},
+        3: {"docid": "doc3", "type": "BASE"},
+        4: {"docid": "doc4", "type": "BASE"},
+    }
+
+    results_exp = result["ranker"]
+    results_exp.items = {
+        1: {"docid": "doc11", "type": "EXP"},
+    }
+
+    interleaved_results = interleave_rankings(results_exp, results_base, 'ranking', rpp=4)
+    interleaved_results = {int(k): v for k, v in interleaved_results.items.items()}
+
     assert interleaved_results in possible_results

--- a/web/test/services/test_interleave_service.py
+++ b/web/test/services/test_interleave_service.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from app.services.interleave_service import tdi, interleave_rankings
+from app.services.interleave_service import interleave_rankings, team_draft_interleave
 from ..create_test_data import create_results
 
 possible_results = [
@@ -38,7 +38,7 @@ def test_tdi():
         2: "doc12",
         3: "doc13",
     }
-    interleaved_results = tdi(item_dict_base, item_dict_exp)
+    interleaved_results = team_draft_interleave([v for v in item_dict_base.values()], [v for v in item_dict_exp.values()], rpp=len(item_dict_base))
 
     # since the interleaving is random if both systems were utelized the same, there are multiple possible results
     assert interleaved_results in possible_results
@@ -61,7 +61,7 @@ def test_interleave_rankings(sessions):
         3: {"docid": "doc13", "type": "EXP"},
     }
 
-    interleaved_results = interleave_rankings(results_exp, results_base)
+    interleaved_results = interleave_rankings(results_exp, results_base, 'ranking', rpp=len(results_base.items))
     # The interleaved dict is added to the Result object which is a JSON type. Therefore the keys are konverted from int to str. Here we revert this conversion.
     interleaved_results = {int(k): v for k, v in interleaved_results.items.items()}
     assert interleaved_results in possible_results

--- a/web/test/services/test_ranking_service.py
+++ b/web/test/services/test_ranking_service.py
@@ -324,7 +324,7 @@ class TestBuildResponse:
             session_id=sessions["ranker"].id,
             system_role="EXP",
         )
-        interleaved_ranking = interleave_rankings(ranking, ranking_base)
+        interleaved_ranking = interleave_rankings(ranking, ranking_base, 'ranking', rpp=len(ranking_base.items))
 
         response = build_response(
             ranking=ranking,
@@ -431,7 +431,7 @@ class TestBuildResponse:
             system_role="EXP",
             system_type="recommendation",
         )
-        interleaved_ranking = interleave_rankings(ranking, ranking_base)
+        interleaved_ranking = interleave_rankings(ranking, ranking_base, 'recommendation', rpp=len(ranking_base.items))
 
         response = build_response(
             ranking=ranking,
@@ -478,7 +478,7 @@ class TestBuildResponse:
             system_role="EXP",
             system_type="recommendation",
         )
-        interleaved_ranking = interleave_rankings(ranking, ranking_base)
+        interleaved_ranking = interleave_rankings(ranking, ranking_base, 'recommendation', rpp=len(ranking_base.items))
 
         response = build_response(
             ranking=ranking,


### PR DESCRIPTION
Team draft interleaving was problematic when one of the systems:
- returns an empty list
- returns fewer results than expected
- responds late

These situations are addressed and resolved, which makes Stella-App return a list of results in any case.

Changes:
- Add: Error handling when a system returns an error or an empty list
- Update: "Team draft interleaving" algorithm
- Update: Related tests

Fixes #92 