### PR TITLE
Fix JSON Result Sorting in API Response

### DIFF
--- a/web/app/api/rankings.py
+++ b/web/app/api/rankings.py
@@ -5,7 +5,7 @@ from app.services.profile_service import profile_route
 from app.services.result_service import make_results
 from app.services.session_service import create_new_session
 from app.services.system_service import get_least_served_system
-from flask import current_app, jsonify, request
+from flask import current_app, jsonify, request, json, Response
 from pytz import timezone
 
 from . import api
@@ -55,7 +55,7 @@ def ranking_from_db(rid):
     """Get a ranking by its result id from the database.
     Tested: true"""
     ranking = db.session.query(Result).get_or_404(rid)
-    return jsonify(ranking.serialize)
+    return Response(json.dumps(ranking.serialize, sort_keys=False, ensure_ascii=False, indent=2), mimetype='application/json')
 
 
 @api.route("/ranking", methods=["GET"])
@@ -86,4 +86,4 @@ def ranking():
 
     response = asyncio.run(make_results(container_name, query, rpp, page, session_id))
 
-    return jsonify(response)
+    return Response(json.dumps(response, sort_keys=False, ensure_ascii=False, indent=2), mimetype='application/json')

--- a/web/app/api/recommendations.py
+++ b/web/app/api/recommendations.py
@@ -5,7 +5,7 @@ from app.models import Feedback, Result, Session, db
 from app.services.result_service import make_results
 from app.services.session_service import create_new_session
 from app.services.system_service import get_least_served_system
-from flask import Response, current_app, jsonify, request
+from flask import Response, current_app, jsonify, request, json
 from pytz import timezone
 
 from . import api
@@ -65,7 +65,7 @@ def ranking_from_db_rec(id: str) -> Tuple[Response, int]:
         Tuple[Response, int]: A tuple where the first element is a Flask JSON response containing a status message, and the second is the HTTP status code (201 or 400).
     """
     ranking = db.session.query(Result).get_or_404(id)
-    return jsonify(ranking.serialize)
+    return Response(json.dumps(ranking.serialize, sort_keys=False, ensure_ascii=False, indent=2), mimetype='application/json')
 
 
 @api.route("/recommendation", methods=["GET"])
@@ -101,4 +101,4 @@ def recommendation():
         )
     )
 
-    return jsonify(response)
+    return Response(json.dumps(response, sort_keys=False, ensure_ascii=False, indent=2), mimetype='application/json')

--- a/web/test/api/test_rankings.py
+++ b/web/test/api/test_rankings.py
@@ -91,8 +91,8 @@ class TestRanking:
         data = result.json
         assert 200 == result.status_code
         # Assert that the structure follows the default STELLA response structure because the baseline system is default
-        assert list(data.keys()) == ["body", "header"]
-        assert list(data["header"].keys()) == [
+        assert set(data.keys()) == {"header", "body"}
+        assert set(data["header"].keys()) == {
             "container",
             "hits",
             "page",
@@ -100,7 +100,7 @@ class TestRanking:
             "rid",
             "rpp",
             "sid",
-        ]
+        }
         for key, item in data["body"].items():
             assert list(item.keys()) == ["docid", "type"]
 
@@ -157,8 +157,8 @@ class TestRanking:
         data = result.json
         assert 200 == result.status_code
         # Assert that the structure follows the default STELLA response structure because the baseline system is default
-        assert list(data.keys()) == ["body", "header"]
-        assert list(data["header"].keys()) == [
+        assert set(data.keys()) == {"header", "body"}
+        assert set(data["header"].keys()) == {
             "container",
             "hits",
             "page",
@@ -166,7 +166,7 @@ class TestRanking:
             "rid",
             "rpp",
             "sid",
-        ]
+        }
         for key, item in data["body"].items():
             assert list(item.keys()) == ["docid", "type"]
 


### PR DESCRIPTION
This PR addresses an issue where the ordering of items in the `body` field of the JSON response was unintentionally changed due to Flask's `jsonify()` function automatically sorting dictionary keys. This caused numeric string keys like `"1"`, `"2"`, ..., `"10"` to appear out of order (e.g., `"10"` before `"2"`), which broke the expected output structure.

Changes Made
- Replaced `jsonify()` with `Response(json.dumps(...))` to gain full control over JSON serialization.
- Updated `test_rankings.py` to make the test independent of the order of response keys

Fixes #87 