### PR TITLE
Feature/true proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ data/*
 
 # ignore local sqlite database
 web/data-dev.sqlite
+
+
+.vscode/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,13 @@
 # Release notes
 All notable changes to this project will be documented in this file. 
 
-## Configure System URLs
+## Improve Proxy Endpoint
+The new proxy endpoint is directly available by `/proxy`. This means it is not part of the standard stella-app API.
+The proxy directly forwards all requests directly to the systems registered to the stella app. The established parameters to control the experiments, e.g., `sid`, `container`, or `system-type` can still be used but need to be prefixed with `stella`.
 
+For interleaved experiments, this endpoint redirects the same request path and parameters to the experimental and baseline systems.
+
+## Configure System URLs
 Previously, the Stella-App accessed ranker/recommender systems using a fixed URL format: `http://{container_name}:5000`. Now, system URLs can be configured through the `SYSTEMS` environment variable in the docker-compose files. If the system URL is not specified, the application will default to using `http://{container_name}:5000`.
 
 Example URL definition:
@@ -16,7 +21,7 @@ SYSTEMS_CONFIG: |
         }
 
 
-## Interleaving made resilient
+## Interleaving Made Resilient
 Team draft interlaving has been updated so the Stella-App returns a result list even when a system:
 - is down or return an empty list
 - returns fewer results than expected

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -31,7 +31,7 @@ services:
       INTERVAL_DB_CHECK: 3
       SESSION_EXPIRATION: 6
       SESSION_KILL: 120
-      SENDFEEDBACK: "True"
+      SENDFEEDBACK: "False"
 
       # Systems
       SYSTEMS_CONFIG: |
@@ -85,6 +85,8 @@ services:
       - ./data/:/data/
     networks:
       - stella-shared
+    ports:
+      - "5000:5000"
 
   gesis_rank_pyserini:
     build: https://github.com/stella-project/gesis_rank_pyserini.git#main
@@ -93,6 +95,8 @@ services:
       - ./data/:/data/
     networks:
       - stella-shared
+    ports:
+      - "5001:5000"
 
   gesis_rec_pyterrier:
     build: https://github.com/stella-project/gesis_rec_pyterrier.git#main
@@ -101,6 +105,8 @@ services:
       - ./data/:/data/
     networks:
       - stella-shared
+    ports:
+      - "5002:5000"
 
   gesis_rec_pyserini:
     build: https://github.com/stella-project/gesis_rec_pyserini.git#main
@@ -109,3 +115,5 @@ services:
       - ./data/:/data/
     networks:
       - stella-shared
+    ports:
+      - "5003:5000"

--- a/web/app/main/__init__.py
+++ b/web/app/main/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 main = Blueprint("main", __name__)
 
-from . import views, index
+from . import index, proxy, views

--- a/web/app/main/proxy.py
+++ b/web/app/main/proxy.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from app.models import Feedback, Result, Session, db
+from app.services.proxy_service import make_results
+from app.services.session_service import create_new_session
+from app.services.system_service import get_least_served_system
+from flask import Flask, Response, current_app, json, jsonify, request
+
+from . import main
+
+
+@main.route("/proxy/<path:url>", methods=["GET"])
+def proxy(url):
+    """Proxy endpoint that directly forwards the request including sub-paths and parameters to the retrieval systems. Only the parameters starting with `stella-` are used by STELLA itself and removed before forwarding the request:
+    - `stella-container`: Name of the container to which the request should be forwarded. If not provided, the least served system is chosen.
+    - `stella-sid`: Session ID. If not provided or invalid, a new session is created. If no session_id or container name is provided consistent results across a session can not be ensured.
+    - `stella-system-type`: Type of the system, either `ranking` or `retrieval`. Defaults to `ranking`. This is to determine the pool of systems for interleaving.
+
+    Args:
+        url (str): The URL path to proxy the request to.
+
+    Returns:
+        Response: The response from the proxied request.
+    """
+    params = request.args.copy()  # copy to make them mutable
+    system_type = params.get("stella-system-type", "ranking")
+
+    # extract stella specific parameters
+    container_name = params.pop("stella-container", None)
+    if container_name is None:
+        current_app.logger.debug("No container name provided")
+        container_name = get_least_served_system()
+
+    session_id = params.pop("stella-sid", None)
+    session_exists = db.session.query(Session).filter_by(id=session_id).first()
+    if not session_exists:
+        session_id = create_new_session(container_name, sid=session_id, type="ranker")
+
+    response = asyncio.run(
+        make_results(container_name, session_id, url, params, system_type=system_type)
+    )
+    current_app.logger.debug(f"Params: {params}")
+    current_app.logger.debug(f"Type of params: {type(params)}")
+
+    return Response(
+        json.dumps(response, sort_keys=False, ensure_ascii=False, indent=2),
+        mimetype="application/json",
+    )

--- a/web/app/main/proxy.py
+++ b/web/app/main/proxy.py
@@ -39,8 +39,6 @@ def proxy(url):
     response = asyncio.run(
         make_results(container_name, session_id, url, params, system_type=system_type)
     )
-    current_app.logger.debug(f"Params: {params}")
-    current_app.logger.debug(f"Type of params: {type(params)}")
 
     return Response(
         json.dumps(response, sort_keys=False, ensure_ascii=False, indent=2),

--- a/web/app/services/interleave_service.py
+++ b/web/app/services/interleave_service.py
@@ -8,7 +8,7 @@ def team_draft_interleave(result_list_base, result_list_exp, rpp):
     # implementation based on https://bitbucket.org/living-labs/ll-api/src/master/ll/core/interleave.py
     """
     Perform Team Draft Interleaving between two ranked lists.
-    
+
     Args:
         result_list_base (List[str]): Ranked list of document IDs from BASE.
         result_list_exp (List[str]): Ranked list of document IDs from EXP.
@@ -39,7 +39,7 @@ def team_draft_interleave(result_list_base, result_list_exp, rpp):
                 while True:
                     doc = next(team_iters[team])
                     if doc not in picked_docs:
-                        interleaved[len(interleaved)+1] = {"docid": doc, "type": team}
+                        interleaved[len(interleaved) + 1] = {"docid": doc, "type": team}
                         picked_docs.add(doc)
                         break
             except StopIteration:
@@ -48,6 +48,7 @@ def team_draft_interleave(result_list_base, result_list_exp, rpp):
                 break
 
     return interleaved
+
 
 def interleave_rankings(ranking_exp, ranking_base, system_type, rpp):
     """
@@ -78,7 +79,7 @@ def interleave_rankings(ranking_exp, ranking_base, system_type, rpp):
         num_found=ranking_exp.num_found,
         hits=ranking_base.num_found,
         page=ranking_exp.page,
-        rpp=rpp,
+        rpp=ranking_exp.rpp,
         items=item_dict,
     )
 

--- a/web/app/services/proxy_service.py
+++ b/web/app/services/proxy_service.py
@@ -38,21 +38,13 @@ async def request_results_from_container(
         f'Start getting results from container: "{container_name}"'
     )
 
-    # Dummy for test
-    # current_app.config["SYSTEMS_CONFIG"][container_name]["docid"] = "id"
-    # current_app.config["SYSTEMS_CONFIG"][container_name]["hits_path"] = parse(
-    #     "$.hits.hits"
-    # )
-
     if current_app.config["SYSTEMS_CONFIG"][container_name].get("url"):
         # Use custom URL if provided in the config
         url = current_app.config["SYSTEMS_CONFIG"][container_name]["url"]
     else:
 
         url = f"http://{container_name}:5000/{url}"
-        # url = f"https://api.econbiz.de/{url}"
 
-    current_app.logger.debug(f"URL: {url}")
     try:
 
         async with session.get(
@@ -168,13 +160,12 @@ async def make_results(
 ):
     """Produce a ranking for the given query and container."""
     # Check cache first
-    # ignore session_id for caching because it may not be available
     # we can only ensure that the same user gets the same results if we have a session_id
     cache_key = f"result:{session_id}:{url}:{params.to_dict(flat=True)}"
     current_app.logger.debug(f"Cache key: {cache_key}")
     cached_result = await current_app.cache.get(cache_key)
     if cached_result:
-        current_app.logger.debug("Ranking cache hit")
+        current_app.logger.debug("Cache hit")
         return cached_result
 
     if current_app.config["INTERLEAVE"]:

--- a/web/app/services/proxy_service.py
+++ b/web/app/services/proxy_service.py
@@ -167,8 +167,6 @@ async def make_results(
     if cached_result:
         current_app.logger.debug("Cache hit")
         return cached_result
-    else:
-        current_app.logger.debug("Cache misssssssssssssssssssss")
 
     if current_app.config["INTERLEAVE"]:
         # get the base system

--- a/web/app/services/proxy_service.py
+++ b/web/app/services/proxy_service.py
@@ -167,6 +167,8 @@ async def make_results(
     if cached_result:
         current_app.logger.debug("Cache hit")
         return cached_result
+    else:
+        current_app.logger.debug("Cache misssssssssssssssssssss")
 
     if current_app.config["INTERLEAVE"]:
         # get the base system
@@ -221,7 +223,7 @@ async def make_results(
         )
         response = build_response(ranking, container_name, result=result)
 
-    if response.get("stella-hits"):
+    if response.get("hits"):
         await current_app.cache.set(
             cache_key, response, ttl=current_app.config["SESSION_EXPIRATION"]
         )

--- a/web/app/services/proxy_service.py
+++ b/web/app/services/proxy_service.py
@@ -1,0 +1,237 @@
+import asyncio
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import aiohttp
+from aiohttp import ClientError, ClientResponseError
+from app.models import Result, System
+from app.services.interleave_service import interleave_rankings
+from app.services.result_service import build_response, extract_hits
+from flask import current_app
+from jsonpath_ng import parse
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.future import select
+from werkzeug.datastructures.structures import MultiDict
+
+
+async def request_results_from_container(
+    session: aiohttp.ClientSession,
+    container_name: str,
+    url: str,
+    params: str,
+) -> dict:
+    """Request results from a system docker container. This is used for both ranking and recommendation systems.
+
+    Args:
+        session (aiohttp.ClientSession): Concurrent session object.
+        container_name (str): Name of the container results are requested from.
+        query (str): Query string or item id for which results are requested.
+        rpp (int): Results Per Page (rpp).
+        page (int): Page ID for pagination.
+        system_type (str, optional): Type of the system (ranking or recommendation). Defaults to "ranking".
+
+    Returns:
+        dict: Dictionary containing the results from the system.
+    """
+    current_app.logger.debug(
+        f'Start getting results from container: "{container_name}"'
+    )
+
+    # Dummy for test
+    # current_app.config["SYSTEMS_CONFIG"][container_name]["docid"] = "id"
+    # current_app.config["SYSTEMS_CONFIG"][container_name]["hits_path"] = parse(
+    #     "$.hits.hits"
+    # )
+
+    if current_app.config["SYSTEMS_CONFIG"][container_name].get("url"):
+        # Use custom URL if provided in the config
+        url = current_app.config["SYSTEMS_CONFIG"][container_name]["url"]
+    else:
+
+        url = f"http://{container_name}:5000/{url}"
+        # url = f"https://api.econbiz.de/{url}"
+
+    current_app.logger.debug(f"URL: {url}")
+    try:
+
+        async with session.get(
+            url=url,
+            params=params,
+            timeout=aiohttp.ClientTimeout(total=3),
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    except asyncio.TimeoutError:
+        current_app.logger.error(
+            f'Timeout while trying to reach "{container_name.upper()}"'
+        )
+    except ClientResponseError as e:
+        current_app.logger.error(
+            f'Client error with "{container_name.upper()}": {e.status} - {e.message}'
+        )
+    except ClientError as e:
+        current_app.logger.error(
+            f'Connection error "{container_name.upper()}": {str(e)}'
+        )
+    except Exception as e:
+        current_app.logger.exception(
+            f'Unexpected error "{container_name.upper()}": {str(e)}'
+        )
+
+    return {
+        "item_id": "query",
+        "itemlist": [],
+        "num_found": 0,
+        "page": "page",
+        "rpp": "rpp",
+    }  # fallback return
+
+
+async def forward_request(
+    container_name: str,
+    url: str,
+    params: Any,
+    session_id: str,
+    system_role: str = "EXP",
+) -> Any:
+    """Equivalent to the query_system function.
+    - We do not need to check for headqueries because this is depricated and we do not parse the query for proxying anymore.
+    """
+    current_app.logger.debug(f'Produce ranking with system: "{container_name}"')
+
+    q_date = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    ts_start = time.time()
+
+    # Get system ID
+    # increase number of request counter before actual request, in case of a failure
+    database_uri = current_app.config["SQLALCHEMY_DATABASE_URI"]
+    if current_app.config["TESTING"]:
+        database_uri = database_uri.replace("sqlite:///", "sqlite+aiosqlite:///")
+    else:
+        database_uri = database_uri.replace("postgresql", "postgresql+asyncpg")
+    async_engine = create_async_engine(database_uri)
+    AsyncSessionLocal = async_sessionmaker(bind=async_engine, expire_on_commit=False)
+
+    async with AsyncSessionLocal() as session:
+        system = (
+            await session.execute(select(System).where(System.name == container_name))
+        ).scalar()
+        system.num_requests_no_head += 1
+        await session.commit()
+
+    # Get the results from the container
+    async with aiohttp.ClientSession() as session:
+        result = await request_results_from_container(
+            session, container_name, url, params
+        )
+
+    item_dict, hits = extract_hits(result, container_name, system_role)
+
+    # calc query execution time in ms
+    ts_end = time.time()
+    q_time = round((ts_end - ts_start) * 1000)
+
+    query = url + str(params)
+    # Save the ranking to the database
+    async with AsyncSessionLocal() as session:
+        system_id = (
+            await session.execute(select(System).where(System.name == container_name))
+        ).scalar()
+
+        ranking = Result(
+            session_id=session_id,
+            system_id=system_id.id,
+            type=system_role,
+            q=query,
+            q_date=q_date,
+            q_time=q_time,
+            num_found=len(hits),
+            page=None,
+            rpp=None,
+            items=item_dict,
+        )
+
+        session.add(ranking)
+        await session.commit()
+
+    return ranking, result
+
+
+async def make_results(
+    container_name: str,
+    session_id: int,
+    url: str,
+    params: MultiDict,
+    system_type: str,
+):
+    """Produce a ranking for the given query and container."""
+    # Check cache first
+    # ignore session_id for caching because it may not be available
+    # we can only ensure that the same user gets the same results if we have a session_id
+    cache_key = f"result:{session_id}:{url}:{params.to_dict(flat=True)}"
+    current_app.logger.debug(f"Cache key: {cache_key}")
+    cached_result = await current_app.cache.get(cache_key)
+    if cached_result:
+        current_app.logger.debug("Ranking cache hit")
+        return cached_result
+
+    if current_app.config["INTERLEAVE"]:
+        # get the base system
+        if system_type == "ranking":
+            container_name_base = current_app.config["RANKING_BASELINE_CONTAINER"]
+        elif system_type == "recommendation":
+            container_name_base = current_app.config["RECOMMENDER_BASELINE_CONTAINER"]
+        current_app.logger.debug("Started gathering")
+
+        # Get results from base system
+        baseline, experimental = await asyncio.gather(
+            forward_request(
+                container_name=container_name_base,
+                url=url,
+                params=params,
+                session_id=session_id,
+                system_role="BASE",
+            ),
+            forward_request(
+                container_name=container_name,
+                url=url,
+                params=params,
+                session_id=session_id,
+                system_role="EXP",
+            ),
+        )
+        ranking_base, result_base = baseline
+        ranking, result = experimental
+
+        interleaved_ranking = interleave_rankings(
+            ranking, ranking_base, system_type, rpp=len(ranking_base.items)
+        )
+
+        response = build_response(
+            ranking=ranking,
+            container_name=container_name,
+            interleaved_ranking=interleaved_ranking,
+            ranking_base=ranking_base,
+            container_name_base=container_name_base,
+            result=result,
+            result_base=result_base,
+        )
+
+    else:
+        # A/B testing
+        ranking, result = await forward_request(
+            container_name=container_name,
+            url=url,
+            params=params,
+            session_id=session_id,
+            system_role="EXP",
+        )
+        response = build_response(ranking, container_name, result=result)
+
+    if response.get("stella-hits"):
+        await current_app.cache.set(
+            cache_key, response, ttl=current_app.config["SESSION_EXPIRATION"]
+        )
+    return response

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -73,7 +73,6 @@ stack-data==0.6.3
 tenacity==8.2.3
 tornado==6.4.1
 traitlets==5.14.1
-typing_extensions==4.9.0
 tzdata==2024.1
 urllib3==2.2.2
 visitor==0.1.3

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -45,7 +45,7 @@ parso==0.8.3
 pexpect==4.9.0
 platformdirs==4.2.0
 plotly==5.18.0
-pluggy==1.4.0
+pluggy==1.6.0
 prompt-toolkit==3.0.43
 psutil==5.9.8
 psycopg2==2.9.9

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -56,7 +56,7 @@ PyGithub==2.2.0
 Pygments==2.17.2
 PyJWT==2.8.0
 PyNaCl==1.5.0
-pytest==8.0.0
+pytest==8.4.0
 pytest-cov==5.0.0
 pytest-mock==3.14.0
 python-dateutil==2.8.2

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -89,3 +89,4 @@ aiohttp==3.11.12
 aiosqlite==0.20.0
 aiocache==0.12.3
 aioresponses==0.7.8
+pytest-asyncio==1.2.0

--- a/web/test/conftest.py
+++ b/web/test/conftest.py
@@ -203,3 +203,24 @@ def mock_request_recommender(aio_mock):
         "mock_url": mock_url,
         "mock_response": mock_response,
     }
+
+
+@pytest.fixture
+def mock_request_custom_system(aio_mock):
+    """Fixture to mock aiohttp requests for a system that does not follows the standard API."""
+    container_name = "system"
+    custom_query = "Test Query"
+    custom_rpp = 10
+    custom_page = 0
+    mock_url = f"http://ranker:5000/custom/path?custom-page={custom_page}&custom-query={custom_query}&custom-rpp={custom_rpp}"
+    mock_response = create_return_experimental()
+
+    aio_mock.get(mock_url, payload=mock_response, repeat=True)
+    return {
+        "container_name": container_name,
+        "custom-query": custom_query,
+        "custom-rpp": custom_rpp,
+        "custom-page": custom_page,
+        "mock_url": mock_url,
+        "mock_response": mock_response,
+    }

--- a/web/test/services/test_proxy_service.py
+++ b/web/test/services/test_proxy_service.py
@@ -1,0 +1,97 @@
+import os
+
+import aiohttp
+import pytest
+from app.models import Result, System
+from app.services.interleave_service import interleave_rankings
+from app.services.proxy_service import (
+    forward_request,
+    make_results,
+    request_results_from_container,
+)
+from werkzeug.datastructures.structures import MultiDict
+
+from ..create_test_data import create_return_experimental
+
+
+class TestRequestResults:
+    """Test the request_results_from_container function."""
+
+    @pytest.mark.asyncio
+    async def test_request_results_from_container(self, mock_request_custom_system):
+        """Test if `request_results_from_container` correctly retrieves and returns API data."""
+        container_name = "ranker"
+        query = "Test Query"
+        rpp = 10
+        page = 0
+
+        async with aiohttp.ClientSession() as session:
+            response = await request_results_from_container(
+                session=session,
+                container_name=container_name,
+                url="custom/path",
+                params={"custom-query": query, "custom-rpp": rpp, "custom-page": page},
+            )
+        print(response)
+        assert response == create_return_experimental()
+
+
+class TestForwardRequest:
+    @pytest.mark.asyncio
+    async def test_forward_request(
+        self, mock_request_custom_system, sessions, db_session
+    ):
+        container_name = "ranker"
+        query = "Test Query"
+        rpp = 10
+        page = 0
+        result = await forward_request(
+            container_name,
+            url="custom/path",
+            params={"custom-query": query, "custom-rpp": rpp, "custom-page": page},
+            session_id=sessions["ranker"].id,
+            system_role="EXP",
+        )
+
+        system = db_session.query(System).filter_by(name=container_name).first()
+        assert system.num_requests_no_head == 1
+
+        result = (
+            db_session.query(Result).filter_by(session_id=sessions["ranker"].id).first()
+        )
+        assert (
+            result.q
+            == "custom/path{'custom-query': 'Test Query', 'custom-rpp': 10, 'custom-page': 0}"
+        )
+        assert result.rpp == None
+        assert result.system_id == system.id
+        print(result.items)
+        for i in range(len(result.items)):
+            assert list(result.items[str(i + 1)].keys()) == ["docid", "type"]
+
+
+class TestMakeResults:
+    @pytest.mark.asyncio
+    async def test_make_results_ab(
+        self, mock_request_custom_system, sessions, db_session
+    ):
+        query = "Test Query"
+        rpp = 10
+        page = 0
+        container_name = "ranker"
+        session_id = sessions["ranker"].id
+        url = "custom/path"
+        params = MultiDict(
+            [("custom-query", query), ("custom-rpp", rpp), ("custom-page", page)]
+        )
+        system_type = "ranking"
+
+        result = await make_results(
+            container_name=container_name,
+            session_id=session_id,
+            url=url,
+            params=params,
+            system_type=system_type,
+        )
+
+        assert result == create_return_experimental()


### PR DESCRIPTION
The new proxy endpoint is directly available by `/proxy`. This means it is not part of the standard stella-app API.
The proxy directly forwards all requests directly to the systems registered to the stella app. The established parameters to control the experiments, e.g., `sid`, `container`, or `system-type` can still be used but need to be prefixed with `stella`.

For interleaved experiments, this endpoint redirects the same request path and parameters to the experimental and baseline systems.
