### PR TITLE
Fix/long queries

### DIFF
--- a/web/app/services/result_service.py
+++ b/web/app/services/result_service.py
@@ -191,6 +191,10 @@ async def query_system(
 
     # truncate long queries to fit in the database
     query = query[: Result.q.property.columns[0].type.length]
+    if len(query) > Result.q.property.columns[0].type.length:
+        current_app.logger.warning(
+            f"Query truncated to {Result.q.property.columns[0].type.length} characters."
+        )
 
     # Save the ranking to the database
     async with AsyncSessionLocal() as session:

--- a/web/test/conftest.py
+++ b/web/test/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from aioresponses import aioresponses
 from app.app import create_app, db
-from app.models import Session
+from app.models import Result, Session
 
 from .create_test_data import (
     create_feedbacks,
@@ -198,6 +198,30 @@ def mock_request_recommender(aio_mock):
     return {
         "container_name": container_name,
         "item_id": query,
+        "rpp": rpp,
+        "page": page,
+        "mock_url": mock_url,
+        "mock_response": mock_response,
+    }
+
+
+@pytest.fixture
+def mock_request_system_long_query(aio_mock):
+    """Fixture to mock aiohttp requests with a really long query"""
+    container_name = "ranker"
+    query = "a" * (Result.q.property.columns[0].type.length + 1)
+    assert len(query) > Result.q.property.columns[0].type.length
+    rpp = 10
+    page = 0
+    mock_url = (
+        f"http://{container_name}:5000/ranking?query={query}&rpp={rpp}&page={page}"
+    )
+    mock_response = create_return_experimental()
+
+    aio_mock.get(mock_url, payload=mock_response, repeat=True)
+    return {
+        "container_name": container_name,
+        "query": query,
         "rpp": rpp,
         "page": page,
         "mock_url": mock_url,


### PR DESCRIPTION
Queries that are longer than the database field could not be handled. To avoid crashes this fix truncates queries to the length specified in the models which is currently at 512.

For the proxy endpoint 512 is not much because all parameters and sub paths are logged as part of the query. Maybe this limit needs to be raised in the future. 


This closes #43
