### PR TITLE
Improve/cron service logging

### DIFF
--- a/web/app/services/cron_service.py
+++ b/web/app/services/cron_service.py
@@ -246,16 +246,18 @@ def post_sessions(sessions_exited):
         if current_app.config["DELETE_SENT_SESSION"]:
             delete_exited_session(session)
 
+sessions_not_exited_prev = 0
 
 def check_db_sessions():
+    global sessions_not_exited_prev
     with scheduler.app.app_context():
-        scheduler.app.logger.info("Scheduler enters task.")
 
         sessions_not_exited = Session.query.filter_by(exit=False, sent=False).all()
 
-        scheduler.app.logger.info(
-            "There is/are " + str(len(sessions_not_exited)) + " running session(s)."
-        )
+        if len(sessions_not_exited) != sessions_not_exited_prev:
+            scheduler.app.logger.info("There is/are " + str(len(sessions_not_exited)) + " running session(s).")
+
+        sessions_not_exited_prev = len(sessions_not_exited)
 
         # set expired sessions to 'exit'
         update_expired_sessions(sessions_not_exited)
@@ -268,4 +270,5 @@ def check_db_sessions():
             update_token()
 
         if len(sessions_exited) > 0:
+            scheduler.app.logger.info("Posting " + str(len(sessions_exited)) + " session(s).")
             post_sessions(sessions_exited)


### PR DESCRIPTION
The Cron service prints out the number of sessions every time it checks session expiration in DEBUG mode. This behavior keeps the log screen busy with redundant information.

With this PR, the logging in `cron_service.py` will be updated, so that 
- The number of active sessions will be printed out only when this number changes
- The number of sessions ready to be posted will be printed out

Fixes #79 