### PR TITLE
Fix/recommender itemid

### DIFF
--- a/web/app/services/result_service.py
+++ b/web/app/services/result_service.py
@@ -39,7 +39,7 @@ async def request_results_from_container(
 
     assert system_type in ["ranking", "recommendation"], "Invalid system type"
 
-    query_key = "item_id" if system_type == "recommendation" else "query"
+    query_key = "itemid" if system_type == "recommendation" else "query"
 
     if current_app.config["SYSTEMS_CONFIG"][container_name].get("url"):
         # Use custom URL if provided in the config
@@ -77,7 +77,7 @@ async def request_results_from_container(
         )
 
     return {
-        "item_id": query,
+        "itemid": query,
         "itemlist": [],
         "num_found": 0,
         "page": page,

--- a/web/test/conftest.py
+++ b/web/test/conftest.py
@@ -169,13 +169,13 @@ def mock_request_base_recommender(aio_mock):
     query = "test_item"
     rpp = 10
     page = 0
-    mock_url = f"http://{container_name}:5000/recommendation?item_id={query}&rpp={rpp}&page={page}"
+    mock_url = f"http://{container_name}:5000/recommendation?itemid={query}&rpp={rpp}&page={page}"
     mock_response = create_return_recommendation_base()
 
     aio_mock.get(mock_url, payload=mock_response, repeat=True)
     return {
         "container_name": container_name,
-        "item_id": query,
+        "itemid": query,
         "rpp": rpp,
         "page": page,
         "mock_url": mock_url,
@@ -190,14 +190,14 @@ def mock_request_recommender(aio_mock):
     query = "test_item"
     rpp = 10
     page = 0
-    mock_url = f"http://{container_name}:5000/recommendation?item_id={query}&rpp={rpp}&page={page}"
+    mock_url = f"http://{container_name}:5000/recommendation?itemid={query}&rpp={rpp}&page={page}"
 
     mock_response = create_return_recommendation_experimental()
 
     aio_mock.get(mock_url, payload=mock_response, repeat=True)
     return {
         "container_name": container_name,
-        "item_id": query,
+        "itemid": query,
         "rpp": rpp,
         "page": page,
         "mock_url": mock_url,

--- a/web/test/create_test_data.py
+++ b/web/test/create_test_data.py
@@ -133,7 +133,7 @@ def create_return_recommendation_base():
         "rpp": rpp,
         "itemlist": itemlist,
         "num_found": len(itemlist),
-        "item_id": "test_item",
+        "itemid": "test_item",
     }
     return data
 

--- a/web/test/services/test_result_service.py
+++ b/web/test/services/test_result_service.py
@@ -74,7 +74,7 @@ class TestRequestResults:
         assert response == create_return_recommendation_base()
         assert response["num_found"] == 10
         assert len(response["itemlist"]) == 10
-        assert response["item_id"] == query
+        assert response["itemid"] == query
         assert response["page"] == page
         assert response["rpp"] == rpp
 


### PR DESCRIPTION
For the recommendation API, Stella-App expects an `itemid` parameter, which specifies the item for which recommendations are generated. Currently, this value is forwarded to the recommender systems using the `item_id` field, causing an inconsistency between the Stella-App request and the recommender systems' request format.

With this PR, Stella-App will use `itemid` consistently when sending the item identifier to the recommender systems.

Note: After this change, recommender systems must be updated to expect the `itemid` field instead of `item_id`.

Fixes #120 