### PR TITLE
Handle: scheduler errors at startup

### DIFF
--- a/web/app/services/cron_service.py
+++ b/web/app/services/cron_service.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 
 import requests as req
+from requests.exceptions import ConnectionError, HTTPError
 from app.extensions import scheduler
 from app.models import Feedback, Result, Session, System, db
 from flask import current_app
@@ -47,13 +48,23 @@ def update_expired_sessions(sessions_not_exited):
 
 
 def update_token():
-    r = req.post(
-        current_app.config["STELLA_SERVER_API"] + "/tokens",
-        auth=(
-            current_app.config["STELLA_SERVER_USER"],
-            current_app.config["STELLA_SERVER_PASS"],
-        ),
-    )
+    try:
+        r = req.post(
+            current_app.config["STELLA_SERVER_API"] + "/tokens",
+            auth=(
+                current_app.config["STELLA_SERVER_USER"],
+                current_app.config["STELLA_SERVER_PASS"],
+            ),
+        )
+        r.raise_for_status()
+
+    except ConnectionError as e:
+        current_app.logger.error(f"Connection error while getting token from STELLA server")
+        return
+    except HTTPError as e:
+        current_app.logger.error(f"HTTP error while getting token from STELLA server: {e}")
+        return
+    
     r_json = json.loads(r.text)
     delta_exp = r_json.get("expiration")
     # get new token five min (300 s) before expiration
@@ -64,15 +75,28 @@ def update_token():
 
 
 def get_side_identifier():
-    r = req.get(
-        current_app.config["STELLA_SERVER_API"]
-        + "/sites/"
-        + current_app.config["STELLA_SERVER_USERNAME"],
-        auth=(current_app.config["STELLA_SERVER_TOKEN"], ""),
-    )
-    r_json = json.loads(r.text)
+    try:
+        r = req.get(
+            current_app.config["STELLA_SERVER_API"]
+            + "/sites/"
+            + current_app.config["STELLA_SERVER_USERNAME"],
+            auth=(current_app.config["STELLA_SERVER_TOKEN"], ""),
+        )
+        r.raise_for_status
 
-    return r_json.get("id")
+        r_json = json.loads(r.text)
+
+        return r_json.get("id")
+    except ConnectionError as e:
+        current_app.logger.error(f"Connection error while getting site identifier from STELLA server")
+        return None
+    except HTTPError as e:
+        current_app.logger.error(f"HTTP error while getting site identifier from STELLA server: {e}")
+        return None
+    except Exception as e:
+        current_app.logger.error(f"Error while getting site identifier from STELLA server: {r.text}")
+        return None
+    
 
 
 def post_session(session, site_id):
@@ -225,10 +249,13 @@ def post_feedbacks(session, session_id_server):
 
 
 def post_sessions(sessions_exited):
+    # get site identifier
+    site_id = get_side_identifier()
+    if site_id is None:
+        current_app.logger.error(f"Posting sessions aborted: Couldn't get site identifier")
+        return
+    
     for session in sessions_exited:
-
-        # get site identifier
-        site_id = get_side_identifier()
 
         # POST session/make new session
         session_id_server = post_session(session, site_id)
@@ -263,11 +290,9 @@ def check_db_sessions():
 
         sessions_exited = Session.query.filter_by(exit=True, sent=False).all()
 
-        if current_app.config["STELLA_SERVER_TOKEN"] is None or current_app.config[
-            "TOKEN_EXPIRATION"
-        ] < datetime.now(timezone.utc):
+        if current_app.config["STELLA_SERVER_TOKEN"] is None or current_app.config["TOKEN_EXPIRATION"] < datetime.now(timezone.utc):
             update_token()
 
-        if len(sessions_exited) > 0:
+        if len(sessions_exited) > 0 and current_app.config["STELLA_SERVER_TOKEN"] is not None:
             scheduler.app.logger.info("Posting " + str(len(sessions_exited)) + " session(s).")
             post_sessions(sessions_exited)


### PR DESCRIPTION
Stella-app scheduler (`cron_service.py`) produces errors when:
- Stella-server is down or not reachable.
- Database of Stella-server is down or not reachable.

Errors are handled, and error messages are added in:
- `update_token()`
- `get_side_identifier()` 

If token or site identifier cannot be obtained from Stella-server, post_sessions() are either avoided or aborted, which prevents further errors.

Fixes #81 