### PR TITLE
fix: support 24 hours and more for SESSION_KILL

### DIFF
--- a/web/app/services/cron_service.py
+++ b/web/app/services/cron_service.py
@@ -13,7 +13,7 @@ def update_expired_sessions(sessions_not_exited):
     for session in sessions_not_exited:
         delta = datetime.now(timezone.utc) - session.start.replace(tzinfo=timezone.utc)
 
-        if delta.seconds > current_app.config["SESSION_EXPIRATION"]:
+        if delta.total_seconds() > current_app.config["SESSION_EXPIRATION"]:
             complete = False
             feedbacks = Feedback.query.filter_by(session_id=session.id).all()
             for feedback in feedbacks:
@@ -27,7 +27,7 @@ def update_expired_sessions(sessions_not_exited):
                 db.session.add(session)
                 db.session.commit()
             else:
-                if current_app.config["SESSION_KILL"] is not None and delta.seconds > current_app.config["SESSION_KILL"]:
+                if current_app.config["SESSION_KILL"] is not None and delta.total_seconds() > current_app.config["SESSION_KILL"]:
                     # 1. get all results that are NOT interleaved results
                     results_not_tdi = Result.query.filter(
                         Result.id != Result.tdi, Result.session_id == session.id


### PR DESCRIPTION
SESSION_KILL can effectively not be set to a value of 24 hours or more, because `delta.seconds` is always less than 24 hours, see [python documentation: datetime.timedelta.seconds](https://docs.python.org/3/library/datetime.html#datetime.timedelta.seconds).

Compare with similar usage in `result_service.py`.

Commit is untested.