### PR TITLE
Refactor post_result and post_results functions to include session_ty…

### DIFF
--- a/web/app/services/cron_service.py
+++ b/web/app/services/cron_service.py
@@ -164,7 +164,7 @@ def post_feedback(feedback, session_id_server):
     return r_json["feedback_id"]
 
 
-def post_result(result, feedback_id_server):
+def post_result(result, feedback_id_server, session_type):
     system = System.query.filter_by(id=result.system_id).first()
     system_name = system.name
     r = req.get(
@@ -188,7 +188,7 @@ def post_result(result, feedback_id_server):
     # post rankings to stella-server with (remote) feedback id
     if current_app.config["INTERLEAVE"]:
         # In interleaved mode, we only expect results of type RANK/REC
-        if result.type == "RANK":
+        if session_type == "RANK":
             r = req.post(
                 current_app.config["STELLA_SERVER_API"]
                 + "/feedbacks/"
@@ -197,7 +197,7 @@ def post_result(result, feedback_id_server):
                 data=payload,
                 auth=(current_app.config["STELLA_SERVER_TOKEN"], ""),
             )
-        elif result.type == "REC":
+        elif session_type == "REC":
             r = req.post(
                 current_app.config["STELLA_SERVER_API"]
                 + "/feedbacks/"
@@ -257,13 +257,15 @@ def delete_exited_session(session):
     db.session.commit()
 
 
-def post_results(results, feedback_id_server):
+def post_results(results, feedback_id_server, session_type):
     for result in results:
         # POST result
-        post_result(result, feedback_id_server)
+        post_result(result, feedback_id_server, session_type)
 
 
 def post_feedbacks(session, session_id_server):
+    session_type = 'RANK' if session.system_ranking is not None else 'REC'
+
     feedbacks = Feedback.query.filter_by(session_id=session.id).all()
     current_app.logger.debug(
         "There is/are " + str(len(feedbacks)) + " feedback(s) to be sent."
@@ -275,7 +277,7 @@ def post_feedbacks(session, session_id_server):
 
         # post results
         results = Result.query.filter_by(feedback_id=feedback.id).all()
-        post_results(results, feedback_id_server)
+        post_results(results, feedback_id_server, session_type)
 
 
 def post_sessions(sessions_exited):


### PR DESCRIPTION
With INTERLEAVED results, only the interleaved result (`type=RANK` or `type=REC`) is sent to the `Stella-Server`. Other results (`type=BASE` or `type=EXP`) are not sent. This cause that the baseline statisctics are not shown on `Stella-Server`.

To fix that, the updated code infers the result type from the related `session`, and sends `BASE` and `EXP` results to `Stella-Server` via the corresponding endpoint (e.g., `feedback/rankings` or `feedback/recommendations`).

This PR fixes #139 