### PR TITLE
Fix/flask trusted host issue

### DIFF
--- a/web/app/main/index.py
+++ b/web/app/main/index.py
@@ -8,8 +8,8 @@ from . import main
 
 @main.route("/index/<string:container_name>")
 def index(container_name):
-    rest_index(container_name)
-    return "Indexing started", 200
+    status_code, body = rest_index(container_name)
+    return body, status_code
 
 
 @main.route("/index/bulk")

--- a/web/app/services/cron_service.py
+++ b/web/app/services/cron_service.py
@@ -67,7 +67,7 @@ def update_token():
         return
     
     r_json = json.loads(r.text)
-    logger.debug("Received new token from Stella Server.", r_json.get("token"))
+    logger.debug("Received new token from Stella Server. Token: %s", r_json.get("token"))
     delta_exp = r_json.get("expiration")
     # get new token five min (300 s) before expiration
     current_app.config["TOKEN_EXPIRATION"] = datetime.now(timezone.utc) + timedelta(

--- a/web/app/services/cron_service.py
+++ b/web/app/services/cron_service.py
@@ -164,7 +164,7 @@ def post_feedback(feedback, session_id_server):
     return r_json["feedback_id"]
 
 
-def post_result(result, feedback_id_server):
+def post_result(result, feedback_id_server, session_type):
     system = System.query.filter_by(id=result.system_id).first()
     system_name = system.name
     r = req.get(
@@ -188,7 +188,7 @@ def post_result(result, feedback_id_server):
     # post rankings to stella-server with (remote) feedback id
     if current_app.config["INTERLEAVE"]:
         # In interleaved mode, we only expect results of type RANK/REC
-        if result.type == "RANK":
+        if session_type == "RANK":
             r = req.post(
                 current_app.config["STELLA_SERVER_API"]
                 + "/feedbacks/"
@@ -197,7 +197,7 @@ def post_result(result, feedback_id_server):
                 data=payload,
                 auth=(current_app.config["STELLA_SERVER_TOKEN"], ""),
             )
-        elif result.type == "REC":
+        elif session_type == "REC":
             r = req.post(
                 current_app.config["STELLA_SERVER_API"]
                 + "/feedbacks/"
@@ -257,13 +257,15 @@ def delete_exited_session(session):
     db.session.commit()
 
 
-def post_results(results, feedback_id_server):
+def post_results(results, feedback_id_server, session_type):
     for result in results:
         # POST result
-        post_result(result, feedback_id_server)
+        post_result(result, feedback_id_server, session_type)
 
 
 def post_feedbacks(session, session_id_server):
+    session_type = 'RANK' if session.system_ranking is not None else 'REC'
+
     feedbacks = Feedback.query.filter_by(session_id=session.id).all()
     current_app.logger.debug(
         "There is/are " + str(len(feedbacks)) + " feedback(s) to be sent."
@@ -275,7 +277,7 @@ def post_feedbacks(session, session_id_server):
 
         # post results
         results = Result.query.filter_by(feedback_id=feedback.id).all()
-        post_results(results, feedback_id_server)
+        post_results(results, feedback_id_server, session_type)
 
 
 def post_sessions(sessions_exited):

--- a/web/app/services/proxy_service.py
+++ b/web/app/services/proxy_service.py
@@ -46,6 +46,7 @@ async def request_results_from_container(
         async with session.get(
             url=url,
             params=params,
+            headers={"Host": "localhost"},
             timeout=aiohttp.ClientTimeout(total=3),
         ) as response:
             response.raise_for_status()

--- a/web/app/services/result_service.py
+++ b/web/app/services/result_service.py
@@ -52,6 +52,7 @@ async def request_results_from_container(
         async with session.get(
             url,
             params={query_key: query, "rpp": rpp, "page": page},
+            headers={"Host": "localhost"},
             timeout=aiohttp.ClientTimeout(total=3),  # optional: set your timeout
         ) as response:
             response.raise_for_status()

--- a/web/app/services/system_service.py
+++ b/web/app/services/system_service.py
@@ -4,13 +4,40 @@ from flask import current_app
 
 
 def rest_index(container_name):
-    if current_app.config["SYSTEMS_CONFIG"][container_name].get("url"):
-        # Use custom URL if provided in the config
-        url = current_app.config["SYSTEMS_CONFIG"][container_name]["url"] + "/index"
-    else:
-        url = f"http://{container_name}:5000/index"
+    try:
+        if current_app.config["SYSTEMS_CONFIG"][container_name].get("url"):
+            # Use custom URL if provided in the config
+            url = current_app.config["SYSTEMS_CONFIG"][container_name]["url"] + "/index"
+        else:
+            url = f"http://{container_name}:5000/index"
+    except KeyError:
+        msg = f"Container '{container_name}' not found in SYSTEMS_CONFIG."
+        current_app.logger.error(msg)
+        return 400, msg
 
-    requests.get(url)
+    try:
+        # Force a trusted Host value while still routing to the container URL
+        response = requests.get(url, timeout=120, headers={"Host": "localhost"})
+        if response.status_code >= 400:
+            current_app.logger.error(
+                "Indexing failed for '%s' (%s): %s %s",
+                container_name,
+                url,
+                response.status_code,
+                response.text,
+            )
+        else:
+            current_app.logger.info(
+                "Indexing succeeded for '%s' (%s): %s",
+                container_name,
+                url,
+                response.status_code,
+            )
+        return response.status_code, response.text
+    except requests.RequestException as exc:
+        msg = f"Indexing request failed for '{container_name}' ({url}): {exc}"
+        current_app.logger.error(msg)
+        return 502, msg
 
 
 def get_least_served_system(query: str = "", type: str = "RANK") -> str:


### PR DESCRIPTION
Newer rebuilds of stella app cause a "host is not trusted 400 error" for indexing, ranking and proxy calls.

This appears related to newer Flask/Werkzeug (version 3.1.3) trusted host validation combined with Docker service-name host headers. The gesis containers currently do not pin a specific flask version in their requirements.txt so rebuilds causes this error.

Current workaround in stella-app sets Host: localhost for internal requests and restores indexing/ranking behavior. 

More details at: https://flask.palletsprojects.com/en/stable/config/#TRUSTED_HOSTS 

Can further pin the flask versions in all the containers but this should work now. 

Closes #141 