### PR TITLE
fix: consider only the systems specified in the docker compose file

### DIFF
--- a/web/app/services/system_service.py
+++ b/web/app/services/system_service.py
@@ -58,6 +58,7 @@ def get_least_served_system(query: str = "", type: str = "RANK") -> str:
         # Select least served container
         container_name = (
             db.session.query(System)
+            .filter(System.name.in_(current_app.config["RANKING_CONTAINER_NAMES"] + current_app.config["RECOMMENDER_CONTAINER_NAMES"]))
             .filter(System.name.notin_(exclude_systems))
             .filter(System.system_type == 'LIVE')
             .order_by(System.num_requests_no_head)


### PR DESCRIPTION
`get_least_served_system()` function selects the system from the `systems` table, even if it is not defined in `SYSTEMS_CONFIG`.

The PR filter systems that only exist in the `SYSTEMS_CONFIG` in `get_least_served_system()` function.

