### PR TITLE
Fix/proxy missing params

### DIFF
--- a/web/app/main/proxy.py
+++ b/web/app/main/proxy.py
@@ -23,7 +23,7 @@ def proxy(url):
       
       It forwards requests to the systems registered to the STELLA app.
 
-      Experiment control parameters (`sid`, `container`, `system-type`, `page`, etc.) must be prefixed with `stella-` when calling this endpoint.
+      Experiment control parameters (`sid`, `container`, `system-type`, `page`, `rpp`, etc.) must be prefixed with `stella-` when calling this endpoint.
       
       Other query parameters are forwarded unchanged. Supports interleaved and non-interleaved experiments.
  
@@ -32,6 +32,7 @@ def proxy(url):
       - **stella-sid**: Session ID. If not provided or invalid, a new session is created.
       - **stella-system-type**: Type of system — either `ranking` or `retrieval`. Defaults to `ranking`.
       - **stella-page**: Optional page indicator for cached results.
+      - **stella-rpp**: Results per page.
 
       All other query parameters are forwarded unchanged to the underlying retrieval service.
     parameters:
@@ -62,6 +63,11 @@ def proxy(url):
         type: integer
         required: false
         description: Page number for cached responses.
+      - name: stella-rpp
+        in: query
+        type: integer
+        required: false
+        description: Results per page.
       - name: query_params
         in: query
         type: object
@@ -86,9 +92,12 @@ def proxy(url):
     # extract stella specific parameters
     params = request.args.copy()  # copy to make them mutable
     system_type = params.pop("stella-system-type", "ranking")
-    page = params.pop("stella-page", None)
     container_name = params.pop("stella-container", None)
-    rpp = params.get("rpp", default=None, type=int)
+
+    page = request.args.get("stella-page", default=None, type=int)
+    rpp = request.args.get("stella-rpp", default=None, type=int)
+    params.pop("stella-page", None)
+    params.pop("stella-rpp", None)
 
     session_id = params.pop("stella-sid", None)
     session_exists = db.session.query(Session).filter_by(id=session_id).first()

--- a/web/app/main/proxy.py
+++ b/web/app/main/proxy.py
@@ -88,6 +88,7 @@ def proxy(url):
     system_type = params.pop("stella-system-type", "ranking")
     page = params.pop("stella-page", None)
     container_name = params.pop("stella-container", None)
+    rpp = params.get("rpp", default=None, type=int)
 
     session_id = params.pop("stella-sid", None)
     session_exists = db.session.query(Session).filter_by(id=session_id).first()
@@ -115,7 +116,7 @@ def proxy(url):
         session_id = create_new_session(container_name, sid=session_id, type=type)
 
     response = asyncio.run(
-        make_results(container_name, session_id, url, params, system_type)
+        make_results(container_name, session_id, url, params, system_type, page, rpp)
     )
 
     return Response(

--- a/web/app/services/proxy_service.py
+++ b/web/app/services/proxy_service.py
@@ -142,7 +142,7 @@ async def forward_request(
         q=query,
         q_date=q_date,
         q_time=q_time,
-        num_found=result.get("num_found", None),
+        num_found=None,
         page=page,
         rpp=rpp,
         items=item_dict,
@@ -197,7 +197,7 @@ async def make_results(
 
 
         interleaved_ranking = interleave_rankings(
-            ranking, ranking_base, system_type, rpp if rpp else len(ranking_base.items)
+            ranking, ranking_base, system_type, rpp if rpp else min(len(ranking.items), len(ranking_base.items)) * 2
         )
 
         response = build_response(

--- a/web/app/services/proxy_service.py
+++ b/web/app/services/proxy_service.py
@@ -88,6 +88,8 @@ async def forward_request(
     url: str,
     params: Any,
     session_id: str,
+    page: int,
+    rpp: int,
     system_role: str = "EXP",
 ) -> Any:
     """Equivalent to the query_system function.
@@ -140,9 +142,9 @@ async def forward_request(
         q=query,
         q_date=q_date,
         q_time=q_time,
-        num_found=None,
-        page=None,
-        rpp=None,
+        num_found=result.get("num_found", None),
+        page=page,
+        rpp=rpp,
         items=item_dict,
     )
 
@@ -158,6 +160,8 @@ async def make_results(
     url: str,
     params: MultiDict,
     system_type: str,
+    page: int,
+    rpp: int,
 ):
     """Produce a ranking for the given query and container."""
     if current_app.config["INTERLEAVE"]:
@@ -173,21 +177,27 @@ async def make_results(
                 url=url,
                 params=params,
                 session_id=session_id,
-                system_role="BASE",
+                page=page,
+                rpp=rpp,
+                system_role="BASE"
             ),
             forward_request(
                 container_name=container_name,
                 url=url,
                 params=params,
                 session_id=session_id,
-                system_role="EXP",
+                page=page,
+                rpp=rpp,
+                system_role="EXP"
             ),
         )
         ranking_base, result_base = baseline
         ranking, result = experimental
 
+
+
         interleaved_ranking = interleave_rankings(
-            ranking, ranking_base, system_type, rpp=len(ranking_base.items)
+            ranking, ranking_base, system_type, rpp if rpp else len(ranking_base.items)
         )
 
         response = build_response(
@@ -207,7 +217,9 @@ async def make_results(
             url=url,
             params=params,
             session_id=session_id,
-            system_role="EXP",
+            page=page,
+            rpp=rpp,
+            system_role="EXP"
         )
         response = build_response(ranking, container_name, result=result)
     return response

--- a/web/test/services/test_proxy_service.py
+++ b/web/test/services/test_proxy_service.py
@@ -46,7 +46,9 @@ class TestForwardRequest:
             url="custom/path",
             params={"custom-query": query, "custom-rpp": rpp, "custom-page": page},
             session_id=sessions["ranker"].id,
-            system_role="EXP",
+            page=page,
+            rpp=rpp,
+            system_role="EXP"
         )
 
         system = db_session.query(System).filter_by(name=container_name).first()
@@ -59,7 +61,7 @@ class TestForwardRequest:
             result.q
             == "custom/path?custom-query=Test Query&custom-rpp=10&custom-page=0"
         )
-        assert result.rpp == None
+        assert result.rpp == rpp
         assert result.system_id == system.id
         for i in range(len(result.items)):
             assert list(result.items[str(i + 1)].keys()) == ["docid", "type"]
@@ -77,7 +79,9 @@ class TestForwardRequest:
             url="custom/path",
             params={"custom-query": query, "custom-rpp": rpp, "custom-page": page},
             session_id=sessions["ranker"].id,
-            system_role="EXP",
+            page=page,
+            rpp=rpp,
+            system_role="EXP"
         )
 
         result = (
@@ -112,6 +116,8 @@ class TestMakeResults:
             url=url,
             params=params,
             system_type=system_type,
+            page=page,
+            rpp=rpp
         )
         assert set(result["_stella"].keys()) == STELLA_RETURN_PARAMETER
 


### PR DESCRIPTION
`rpp` and `page` are not passed to the proxy endpoint-related functions, such as `make_results()` and `forward_request()`.

Complications:
- `rpp` is inferred as `len(ranking_base.items)`, which can be different from the intended `rpp`.
- `rpp` and `page` parameters are set to None while creating `Result` entries in `forward_request()`. 

Fix: 
- `rpp` is read in `proxy` endpoint and passed to `make_results()` and  `forward_request()` functions.
- if `rpp` is not provided in the request, it is assumed to be `len(ranking_base.items)`.